### PR TITLE
Fix card display on next page

### DIFF
--- a/index2.css
+++ b/index2.css
@@ -64,7 +64,7 @@ img { max-width: 100%; display: block; }
 .hero {
   position: relative;
   min-height: 94vh;
-  overflow: hidden;
+  overflow: visible;
   background: #18a092; /* base teal close to reference */
 }
 


### PR DESCRIPTION
Set hero section overflow to visible to prevent cards from being hidden.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2da1525-2603-46f7-a084-60355bcc1f5a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e2da1525-2603-46f7-a084-60355bcc1f5a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

